### PR TITLE
Restrict user document creation to owning user

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,7 +35,7 @@ service cloud.firestore {
     match /users/{userId} {
       allow read, write: if isAuthenticated() && request.auth.uid == userId;
       allow read: if isAdmin();
-      allow create: if isAuthenticated();
+      allow create: if isAuthenticated() && request.auth.uid == userId;
     }
 
     // Leads collection


### PR DESCRIPTION
## Summary
- require authenticated user ID to match userId when creating `/users/{userId}`

## Testing
- `npm test` *(fails: Missing script "test")*
- `firebase deploy --only firestore:rules` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b374bff93083338e70e3584e73b4f2