### PR TITLE
Use raw payload and HTTP for Stripe webhook

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,8 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
+// Use raw body for Stripe webhooks before any body parsers
+app.use('/api/stripe/webhook', express.raw({ type: 'application/json' }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 


### PR DESCRIPTION
## Summary
- send Stripe webhook to deployed function via HTTP instead of `httpsCallable`
- ensure raw body middleware is applied before body parsers for Stripe webhook route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b374be2acc8333aa9efe7db82d27af