### PR TITLE
feat: add server firebase client

### DIFF
--- a/server/firebase-client.ts
+++ b/server/firebase-client.ts
@@ -1,0 +1,30 @@
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getFunctions, connectFunctionsEmulator, type Functions } from 'firebase/functions';
+
+let functions: Functions | null = null;
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const apiKey = process.env.FIREBASE_API_KEY;
+
+if (projectId && apiKey) {
+  const firebaseConfig = {
+    apiKey,
+    authDomain: `${projectId}.firebaseapp.com`,
+    projectId,
+    storageBucket: `${projectId}.appspot.com`,
+    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.FIREBASE_APP_ID,
+  };
+
+  const app: FirebaseApp = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  functions = getFunctions(app);
+
+  if (process.env.FIREBASE_FUNCTIONS_EMULATOR === 'true') {
+    connectFunctionsEmulator(functions, 'localhost', 5001);
+  }
+} else {
+  console.log('Firebase functions not configured - running in demo mode');
+}
+
+export { functions };
+export default functions;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { httpsCallable } from 'firebase/functions';
-import { functions } from '../client/src/lib/firebase';
+import { functions } from './firebase-client';
 
 // Demo mode responses
 const demoResponses = {


### PR DESCRIPTION
## Summary
- add server firebase client to initialize callable Firebase functions
- use new server Firebase client in route definitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b374aba3d483338d41dc455eea1194