### PR TITLE
Handle errors without rethrowing in Express middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -42,9 +42,10 @@ app.use((req, res, next) => {
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
+    // Log the error so it can be inspected without crashing the server
+    log(err?.stack ?? String(err), "error");
 
     res.status(status).json({ message });
-    throw err;
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- Log server errors instead of rethrowing them
- Prevent error-handling middleware from propagating exceptions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Argument of type 'null' is not assignable to parameter of type 'Query<unknown, DocumentData>' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b374bbcc308333b67f8d910a383600