### PR TITLE
Fix Stripe webhook verification using raw body

### DIFF
--- a/server/functions/stripeWebhook.ts
+++ b/server/functions/stripeWebhook.ts
@@ -30,7 +30,7 @@ export const stripeWebhook = https.onRequest(async (req, res) => {
     let event: Stripe.Event;
     
     try {
-      event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
+      event = stripe.webhooks.constructEvent(req.rawBody, sig, webhookSecret);
     } catch (err: any) {
       console.error(`Webhook signature verification failed: ${err.message}`);
       res.status(400).send(`Webhook Error: ${err.message}`);

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,12 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
+
+// Stripe needs the raw body to verify webhook signatures.
+// We add this before the JSON parser so that express.json() doesn't
+// consume the body for this endpoint.
+app.use("/api/stripe/webhook", express.raw({ type: "application/json" }));
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -121,7 +121,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const stripeWebhook = httpsCallable(functions, 'stripeWebhook');
       const result = await stripeWebhook({
         signature: req.headers['stripe-signature'],
-        body: req.body
+        // When using express.raw middleware, req.body is a Buffer.
+        // Send it as a string so the callable function receives the
+        // original payload for signature verification.
+        body: req.body instanceof Buffer ? req.body.toString() : req.body
       });
       res.json(result.data);
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Verify Stripe webhook signatures against raw request payload
- Bypass JSON parsing for `/api/stripe/webhook` so raw body is available
- Forward raw webhook payload as string when proxying to Firebase function

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors)*
- `node --input-type=module -e "import Stripe from 'stripe'; const stripe=new Stripe('sk_test_123',{apiVersion:'2023-10-16'}); const payload=JSON.stringify({id:'evt_test', object:'event'}); const secret='whsec_test_secret'; const header=stripe.webhooks.generateTestHeaderString({payload, secret}); try{stripe.webhooks.constructEvent(Buffer.from(payload), header, secret); console.log('Signature verified');}catch(e){console.error('Verification failed', e.message);}"`


------
https://chatgpt.com/codex/tasks/task_e_68b374acf0c483338beded38e09ee197