### PR TITLE
chore: import firebase auth helpers in useAuth

### DIFF
--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -1,5 +1,14 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { User } from '@shared/schema';
+import { auth } from '@/lib/firebase';
+import { createUser } from '@/lib/firestore';
+import {
+  createUserWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithEmailAndPassword,
+  signInWithRedirect,
+  signOut
+} from 'firebase/auth';
 
 type FirebaseUser = any; // Not using real Firebase
 


### PR DESCRIPTION
## Summary
- import Firebase auth instance and helpers in `useAuth`

## Testing
- `npm run check` *(fails: Argument of type 'null' is not assignable to type 'Auth', plus other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b374a9ece48333af5d6d7f91bfaaee