### PR TITLE
fix: center add lead dialog

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -29,7 +29,6 @@ html {
 /* Improve paint performance */
 .glass {
   will-change: transform;
-  transform: translateZ(0);
   contain: layout style paint;
 }
 


### PR DESCRIPTION
## Summary
- remove translateZ transform from global `glass` class so dialogs keep Tailwind translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find name 'signInWithEmailAndPassword', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e810fc483338cae9172c393f47a